### PR TITLE
feat: add language param to editorConfig

### DIFF
--- a/classes/editor.php
+++ b/classes/editor.php
@@ -99,6 +99,7 @@ class editor {
         $user['id'] = $USER->id;
         $user['name'] = \fullname($USER);
         $editorconfig['user'] = $user;
+        $editorconfig['lang'] = stristr($USER->lang, '_', true) !== false ? stristr($USER->lang, '_', true) : $USER->lang;
 
         // customization
         $customization = [];


### PR DESCRIPTION
Currently, the onlyoffice interface is always displayed in English.
This PR displays the onlyoffice interface in the language configured by the user in moodle.
This code comes from the following mod_onlyofficeeditor plugin commits :
* [eed5736dd3cae5137c4b0d9b5ef4e2de0f7c040e](https://github.com/ONLYOFFICE/moodle-mod_onlyofficeeditor/commit/eed5736dd3cae5137c4b0d9b5ef4e2de0f7c040e)
* [dc51347df283e707fe9135d4c1c3c19a1a9b3781](https://github.com/ONLYOFFICE/moodle-mod_onlyofficeeditor/commit/dc51347df283e707fe9135d4c1c3c19a1a9b3781)